### PR TITLE
 Refined Spring endpoint handling and introduced maintainable test fixtures.

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,6 +6,8 @@
   <component name="ChangeListManager">
     <list default="true" id="6f5ee0ad-1dd2-4e8c-9f9f-d7dfd4de6aa6" name="Changes" comment="Move git ignore">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docgen/analyzers/structure.py" beforeDir="false" afterPath="$PROJECT_DIR$/docgen/analyzers/structure.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/tests/analyzers/test_structure.py" beforeDir="false" afterPath="$PROJECT_DIR$/tests/analyzers/test_structure.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -33,28 +35,28 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
-    &quot;Python tests.Python tests for tests.git.test_publisher.test_publisher_noop_without_git_repo.executor&quot;: &quot;Run&quot;,
-    &quot;Python tests.Python tests for tests.llm.test_runner.test_llm_runner_constructs_request.executor&quot;: &quot;Run&quot;,
-    &quot;Python tests.Python tests for tests.rag.test_indexer.test_rag_indexer_builds_contexts.executor&quot;: &quot;Run&quot;,
-    &quot;Python tests.Python tests for tests.test_config.test_load_config_returns_defaults_when_missing.executor&quot;: &quot;Run&quot;,
-    &quot;Python tests.Python tests for tests.test_orchestrator.test_run_init_creates_readme_with_quickstart.executor&quot;: &quot;Run&quot;,
-    &quot;Python tests.Python tests for tests.test_orchestrator.test_run_init_refuses_to_overwrite_existing_readme.executor&quot;: &quot;Run&quot;,
-    &quot;Python tests.Python tests for tests.test_repo_scanner.test_scan_builds_manifest_with_roles_and_language.executor&quot;: &quot;Run&quot;,
-    &quot;Python tests.Python tests for tests.test_repo_scanner.test_scan_rejects_missing_directory.executor&quot;: &quot;Run&quot;,
-    &quot;Python tests.Python tests in test_builder.py.executor&quot;: &quot;Run&quot;,
-    &quot;Python tests.Python tests in tests.executor&quot;: &quot;Run&quot;,
-    &quot;Python.test.executor&quot;: &quot;Run&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;SONARLINT_PRECOMMIT_ANALYSIS&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;master&quot;,
-    &quot;ignore.virus.scanning.warn.message&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "Python tests.Python tests for tests.git.test_publisher.test_publisher_noop_without_git_repo.executor": "Run",
+    "Python tests.Python tests for tests.llm.test_runner.test_llm_runner_constructs_request.executor": "Run",
+    "Python tests.Python tests for tests.rag.test_indexer.test_rag_indexer_builds_contexts.executor": "Run",
+    "Python tests.Python tests for tests.test_config.test_load_config_returns_defaults_when_missing.executor": "Run",
+    "Python tests.Python tests for tests.test_orchestrator.test_run_init_creates_readme_with_quickstart.executor": "Run",
+    "Python tests.Python tests for tests.test_orchestrator.test_run_init_refuses_to_overwrite_existing_readme.executor": "Run",
+    "Python tests.Python tests for tests.test_repo_scanner.test_scan_builds_manifest_with_roles_and_language.executor": "Run",
+    "Python tests.Python tests for tests.test_repo_scanner.test_scan_rejects_missing_directory.executor": "Run",
+    "Python tests.Python tests in test_builder.py.executor": "Run",
+    "Python tests.Python tests in tests.executor": "Run",
+    "Python.test.executor": "Run",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "SONARLINT_PRECOMMIT_ANALYSIS": "true",
+    "git-widget-placeholder": "task/endpoint__abstraction",
+    "ignore.virus.scanning.warn.message": "true"
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="C:\Users\chris\PycharmProjects\docgen" />

--- a/docgen/analyzers/endpoints/__init__.py
+++ b/docgen/analyzers/endpoints/__init__.py
@@ -1,0 +1,3 @@
+"""Endpoint detection utilities for docgen analyzers."""
+
+__all__ = []

--- a/docgen/analyzers/endpoints/core.py
+++ b/docgen/analyzers/endpoints/core.py
@@ -1,0 +1,127 @@
+"""Shared endpoint detection helpers."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Protocol, Sequence, Tuple
+
+
+@dataclass(frozen=True)
+class Endpoint:
+    """Normalized representation of an HTTP endpoint."""
+
+    method: str
+    path: str
+    file: str
+    line: Optional[int] = None
+    framework: Optional[str] = None
+    language: Optional[str] = None
+    confidence: float = 1.0
+
+
+class EndpointDetector(Protocol):
+    """Contract for detectors that emit endpoints from a manifest."""
+
+    def supports_repo(self, manifest) -> bool:  # noqa: ANN001 - typed dynamically
+        ...
+
+    def extract(self, manifest) -> Iterable[Endpoint]:  # noqa: ANN001 - typed dynamically
+        ...
+
+
+_PARAM_PATTERNS: List[Tuple[re.Pattern[str], str]] = [
+    (re.compile(r"/:([A-Za-z_][A-Za-z0-9_]*)"), r"/{\1}"),
+    (re.compile(r"/<(?:(?:[A-Za-z_][A-Za-z0-9_]*):)?([A-Za-z_][A-Za-z0-9_]*)>"), r"/{\1}"),
+    (re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\s*:\s*[^}]+\}"), r"{\1}"),
+    (re.compile(r"\(\?P<([A-Za-z_][A-Za-z0-9_]*)>[^)]+\)"), r"{\1}"),
+]
+
+
+def normalize_path(path: str) -> str:
+    """Return a canonical representation for endpoint paths."""
+    if not path:
+        return "/"
+    result = path.strip()
+    if not result.startswith("/"):
+        result = "/" + result
+    for pattern, replacement in _PARAM_PATTERNS:
+        result = pattern.sub(replacement, result)
+    result = re.sub(r"/{2,}", "/", result)
+    if len(result) > 1 and result.endswith("/"):
+        result = result[:-1]
+    return result or "/"
+
+
+def join_paths(prefix: str, route: str) -> str:
+    """Combine class-level and method-level paths."""
+    prefix_norm = normalize_path(prefix) if prefix else ""
+    route_norm = normalize_path(route)
+    if not prefix_norm:
+        return route_norm
+    if route_norm == "/":
+        return prefix_norm
+    combined = f"{prefix_norm}{route_norm}"
+    return normalize_path(combined)
+
+
+def method_upper(value: str) -> str:
+    """Normalize HTTP verbs to uppercase."""
+    return (value or "").strip().upper()
+
+
+def line_of(text: str, index: int) -> int:
+    """Return 1-based line number for a character index."""
+    return text.count("\n", 0, index) + 1
+
+
+def pick_higher_confidence(existing: Endpoint, new: Endpoint) -> Endpoint:
+    """Choose the endpoint with higher confidence, preferring specs when equal."""
+    if new.confidence > existing.confidence:
+        return new
+    if new.confidence < existing.confidence:
+        return existing
+    rank = {"spec": 3, "framework": 2, "heuristic": 1}
+    existing_rank = rank.get((existing.framework or "").lower(), 0)
+    new_rank = rank.get((new.framework or "").lower(), 0)
+    return new if new_rank > existing_rank else existing
+
+
+class DetectorRegistry:
+    """Executes endpoint detectors and deduplicates outputs."""
+
+    def __init__(self, detectors: Sequence[EndpointDetector]) -> None:
+        self._detectors = list(detectors)
+
+    def run(self, manifest) -> List[Endpoint]:  # noqa: ANN001 - dynamic type
+        results: Dict[Tuple[str, str], Endpoint] = {}
+        for detector in self._detectors:
+            if not detector.supports_repo(manifest):
+                continue
+            for endpoint in detector.extract(manifest):
+                method = method_upper(endpoint.method)
+                path = normalize_path(endpoint.path)
+                normalized = Endpoint(
+                    method=method,
+                    path=path,
+                    file=endpoint.file,
+                    line=endpoint.line,
+                    framework=endpoint.framework,
+                    language=endpoint.language,
+                    confidence=endpoint.confidence,
+                )
+                key = (method, path)
+                if key in results:
+                    results[key] = pick_higher_confidence(results[key], normalized)
+                else:
+                    results[key] = normalized
+        return sorted(results.values(), key=lambda ep: (ep.path, ep.method))
+
+
+__all__ = [
+    "Endpoint",
+    "EndpointDetector",
+    "DetectorRegistry",
+    "join_paths",
+    "line_of",
+]

--- a/docgen/analyzers/endpoints/detectors.py
+++ b/docgen/analyzers/endpoints/detectors.py
@@ -1,0 +1,330 @@
+"""Built-in endpoint detectors."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Iterable, Iterator, Optional
+
+from .core import Endpoint, EndpointDetector, join_paths, line_of
+
+
+def _read_text(root: Path, relative: str) -> Optional[str]:
+    path = root / relative
+    try:
+        if path.exists() and path.is_file():
+            return path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Specification detectors (OpenAPI / Postman / Insomnia)
+# ---------------------------------------------------------------------------
+
+_SPEC_PATTERN = re.compile(r"(openapi|swagger).*?\.(json|ya?ml)$", re.IGNORECASE)
+_POSTMAN_PATTERN = re.compile(r"postman_collection\.json$", re.IGNORECASE)
+_INSOMNIA_PATTERN = re.compile(r"insomnia.*\.json$", re.IGNORECASE)
+
+
+class SpecDetector(EndpointDetector):
+    """Parse API specification files when available."""
+
+    def supports_repo(self, manifest) -> bool:  # noqa: ANN001 - dynamic typing
+        return any(
+            _SPEC_PATTERN.search(file.path)
+            or _POSTMAN_PATTERN.search(file.path)
+            or _INSOMNIA_PATTERN.search(file.path)
+            for file in manifest.files
+        )
+
+    def extract(self, manifest) -> Iterable[Endpoint]:  # noqa: ANN001 - dynamic typing
+        root = Path(manifest.root)
+        for file in manifest.files:
+            path = file.path
+            if _SPEC_PATTERN.search(path):
+                yield from self._from_openapi(root, path)
+            elif _POSTMAN_PATTERN.search(path):
+                yield from self._from_postman(root, path)
+            elif _INSOMNIA_PATTERN.search(path):
+                yield from self._from_insomnia(root, path)
+
+    def _from_openapi(self, root: Path, relative: str) -> Iterable[Endpoint]:
+        text = _read_text(root, relative)
+        if text is None:
+            return []
+        try:
+            if relative.lower().endswith((".yaml", ".yml")):
+                try:
+                    import yaml  # type: ignore
+                except Exception:
+                    return []
+                data = yaml.safe_load(text)  # type: ignore[attr-defined]
+            else:
+                data = json.loads(text)
+        except Exception:
+            return []
+        if not isinstance(data, dict):
+            return []
+        paths = data.get("paths")
+        if not isinstance(paths, dict):
+            return []
+        for raw_path, mapping in paths.items():
+            if not isinstance(mapping, dict):
+                continue
+            for method in mapping.keys():
+                verb = method.upper()
+                if verb not in {"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"}:
+                    continue
+                yield Endpoint(
+                    method=verb,
+                    path=raw_path,
+                    file=relative,
+                    framework="spec",
+                    confidence=1.0,
+                )
+        return []
+
+    def _from_postman(self, root: Path, relative: str) -> Iterable[Endpoint]:
+        text = _read_text(root, relative)
+        if text is None:
+            return []
+        try:
+            data = json.loads(text)
+        except Exception:
+            return []
+        items = data.get("item")
+        if not isinstance(items, list):
+            return []
+        for method, path in self._walk_postman(items):
+            yield Endpoint(
+                method=method,
+                path=path,
+                file=relative,
+                framework="spec",
+                confidence=1.0,
+            )
+        return []
+
+    def _walk_postman(self, items) -> Iterator[tuple[str, str]]:
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            nested = item.get("item")
+            if isinstance(nested, list):
+                yield from self._walk_postman(nested)
+                continue
+            request = item.get("request")
+            if not isinstance(request, dict):
+                continue
+            method = (request.get("method") or "").upper()
+            if not method:
+                continue
+            url = request.get("url") or {}
+            path_segments = url.get("path") if isinstance(url, dict) else None
+            if isinstance(path_segments, list) and path_segments:
+                path = "/" + "/".join(segment.strip("/") for segment in path_segments if isinstance(segment, str))
+            else:
+                raw = url.get("raw") if isinstance(url, dict) else None
+                path = raw or "/"
+            yield method, path or "/"
+
+    def _from_insomnia(self, root: Path, relative: str) -> Iterable[Endpoint]:
+        text = _read_text(root, relative)
+        if text is None:
+            return []
+        try:
+            data = json.loads(text)
+        except Exception:
+            return []
+        resources: list = []
+        if isinstance(data, list):
+            resources = data
+        elif isinstance(data, dict):
+            maybe = data.get("resources")
+            if isinstance(maybe, list):
+                resources = maybe
+        for resource in resources:
+            if not isinstance(resource, dict):
+                continue
+            if resource.get("_type") != "request":
+                continue
+            method = (resource.get("method") or "").upper()
+            url = resource.get("url") or ""
+            if not method or not url:
+                continue
+            match = re.search(r"https?://[^/]+(/[^?#]*)", url)
+            path = match.group(1) if match else url
+            yield Endpoint(
+                method=method,
+                path=path,
+                file=relative,
+                framework="spec",
+                confidence=1.0,
+            )
+        return []
+
+# ---------------------------------------------------------------------------
+# FastAPI detector
+# ---------------------------------------------------------------------------
+
+_FASTAPI_PATTERN = re.compile(
+    r"@(?P<router>\w+)\.(?P<verb>get|post|put|delete|patch)\((['\"])(?P<path>[^'\"]+)\3",
+    re.IGNORECASE,
+)
+
+
+class FastAPIDetector(EndpointDetector):
+    """Locate FastAPI route decorators."""
+
+    def supports_repo(self, manifest) -> bool:  # noqa: ANN001 - dynamic typing
+        return any(file.language == "Python" for file in manifest.files)
+
+    def extract(self, manifest) -> Iterable[Endpoint]:  # noqa: ANN001 - dynamic typing
+        root = Path(manifest.root)
+        for file in manifest.files:
+            if file.language != "Python":
+                continue
+            text = _read_text(root, file.path)
+            if not text:
+                continue
+            for match in _FASTAPI_PATTERN.finditer(text):
+                yield Endpoint(
+                    method=match.group("verb").upper(),
+                    path=match.group("path"),
+                    file=file.path,
+                    line=line_of(text, match.start()),
+                    framework="FastAPI",
+                    language="Python",
+                    confidence=0.95,
+                )
+
+
+# ---------------------------------------------------------------------------
+# Express detector
+# ---------------------------------------------------------------------------
+
+_EXPRESS_PATTERN = re.compile(
+    r"(?:\b(app|router)\b)\.(?P<verb>get|post|put|delete|patch)\s*\(\s*(['\"])(?P<path>[^'\"]+)\3",
+    re.IGNORECASE,
+)
+
+
+class ExpressDetector(EndpointDetector):
+    """Detect Express-style router verb invocations."""
+
+    def supports_repo(self, manifest) -> bool:  # noqa: ANN001 - dynamic typing
+        return any(file.language in {"JavaScript", "TypeScript"} for file in manifest.files)
+
+    def extract(self, manifest) -> Iterable[Endpoint]:  # noqa: ANN001 - dynamic typing
+        root = Path(manifest.root)
+        for file in manifest.files:
+            if file.language not in {"JavaScript", "TypeScript"}:
+                continue
+            if not file.path.endswith((".js", ".jsx", ".ts", ".tsx")):
+                continue
+            text = _read_text(root, file.path)
+            if not text:
+                continue
+            for match in _EXPRESS_PATTERN.finditer(text):
+                yield Endpoint(
+                    method=match.group("verb").upper(),
+                    path=match.group("path"),
+                    file=file.path,
+                    line=line_of(text, match.start()),
+                    framework="Express",
+                    language=file.language,
+                    confidence=0.93,
+                )
+
+
+# ---------------------------------------------------------------------------
+# Spring MVC detector
+# ---------------------------------------------------------------------------
+
+_SPRING_SHORT = re.compile(
+    r"@(?P<verb>Get|Post|Put|Delete|Patch)Mapping\s*\(\s*(?:value|path\s*=\s*)?(?P<quote>['\"])(?P<path>[^'\"]+)(?P=quote)",
+    re.IGNORECASE,
+)
+_SPRING_REQUEST_MAPPING = re.compile(r"@RequestMapping\s*\(\s*(?P<args>[^)]*)\)", re.DOTALL | re.IGNORECASE)
+
+
+class SpringDetector(EndpointDetector):
+    """Extract Spring MVC request mappings."""
+
+    def supports_repo(self, manifest) -> bool:  # noqa: ANN001 - dynamic typing
+        return any(
+            file.language in {"Java", "Kotlin"} and file.path.endswith((".java", ".kt"))
+            for file in manifest.files
+        )
+
+    def extract(self, manifest) -> Iterable[Endpoint]:  # noqa: ANN001 - dynamic typing
+        root = Path(manifest.root)
+        for file in manifest.files:
+            if file.language not in {"Java", "Kotlin"}:
+                continue
+            if not file.path.endswith((".java", ".kt")):
+                continue
+            text = _read_text(root, file.path)
+            if not text:
+                continue
+            class_base = self._resolve_class_base(text)
+            for match in _SPRING_SHORT.finditer(text):
+                yield Endpoint(
+                    method=match.group("verb").upper(),
+                    path=join_paths(class_base, match.group("path")),
+                    file=file.path,
+                    line=line_of(text, match.start()),
+                    framework="Spring",
+                    language=file.language,
+                    confidence=0.95,
+                )
+            for match in _SPRING_REQUEST_MAPPING.finditer(text):
+                verb = self._extract_request_method(match.group("args"))
+                route = self._extract_request_path(match.group("args"))
+                if not verb or not route:
+                    continue
+                yield Endpoint(
+                    method=verb,
+                    path=join_paths(class_base, route),
+                    file=file.path,
+                    line=line_of(text, match.start()),
+                    framework="Spring",
+                    language=file.language,
+                    confidence=0.95,
+                )
+
+    @staticmethod
+    def _resolve_class_base(text: str) -> str:
+        class_mapping = re.search(r"@RequestMapping\s*\(\s*(?P<args>[^)]*)\)\s*(?:public\s+|protected\s+|private\s+)?class", text, re.DOTALL | re.IGNORECASE)
+        if not class_mapping:
+            return ""
+        path = SpringDetector._extract_request_path(class_mapping.group("args"))
+        return path or ""
+
+    @staticmethod
+    def _extract_request_method(args: str) -> Optional[str]:
+        match = re.search(r"method\s*=\s*RequestMethod\.(GET|POST|PUT|DELETE|PATCH)", args, re.IGNORECASE)
+        if match:
+            return match.group(1).upper()
+        return None
+
+    @staticmethod
+    def _extract_request_path(args: str) -> Optional[str]:
+        named = re.search(r"(?:value|path)\s*=\s*(?P<quote>['\"])(?P<path>[^'\"]+)(?P=quote)", args)
+        if named:
+            return named.group("path")
+        positional = re.search(r"(?P<quote>['\"])(?P<path>[^'\"]+)(?P=quote)", args)
+        if positional:
+            return positional.group("path")
+        return None
+
+
+__all__ = [
+    "SpecDetector",
+    "FastAPIDetector",
+    "ExpressDetector",
+    "SpringDetector",
+]

--- a/tests/_fixtures/repo_builder.py
+++ b/tests/_fixtures/repo_builder.py
@@ -1,0 +1,38 @@
+"""Helper utilities for constructing temporary repositories in tests."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from typing import Mapping
+
+from docgen.repo_scanner import RepoScanner
+from docgen.models import RepoManifest
+
+
+class RepoBuilder:
+    """Utility for writing files into a throwaway repository and rescanning it."""
+
+    def __init__(self, tmp_path: Path) -> None:
+        self.root = tmp_path / "repo"
+        self.root.mkdir()
+        self._scanner = RepoScanner()
+
+    def write(self, files: Mapping[str, str]) -> None:
+        """Write `path -> contents` entries into the repository."""
+        for relative, content in files.items():
+            path = self.root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            normalised = textwrap.dedent(content).lstrip("\n")
+            path.write_text(normalised, encoding="utf-8")
+
+    def scan(self) -> RepoManifest:
+        """Return a fresh manifest of the repository contents."""
+        return self._scanner.scan(str(self.root))
+
+    def path(self) -> Path:
+        """Return the repository root path."""
+        return self.root
+
+
+__all__ = ["RepoBuilder"]

--- a/tests/analyzers/test_structure.py
+++ b/tests/analyzers/test_structure.py
@@ -2,55 +2,130 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+import json
 
 from docgen.analyzers.structure import StructureAnalyzer
-from docgen.repo_scanner import RepoScanner
+from tests._fixtures.repo_builder import RepoBuilder
 
 
-def _write(path: Path, content: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(content, encoding="utf-8")
+def test_structure_analyzer_detects_fastapi_and_spring_endpoints(repo_builder: RepoBuilder) -> None:
+    repo_builder.write(
+        {
+            "api/users.py": """
+                from fastapi import APIRouter
 
+                router = APIRouter()
 
-def test_structure_analyzer_detects_fastapi_sequence(tmp_path: Path) -> None:
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _write(
-        repo / "app" / "api.py",
-        """
-from fastapi import FastAPI
-import requests
+                @router.get("/users/{id}")
+                def get_user(user_id: int):
+                    return {"id": user_id}
+            """,
+            "src/UserController.java": """
+                import org.springframework.web.bind.annotation.GetMapping;
+                import org.springframework.web.bind.annotation.PathVariable;
+                import org.springframework.web.bind.annotation.RequestMapping;
+                import org.springframework.web.bind.annotation.RestController;
 
-app = FastAPI()
-
-@app.get("/login")
-async def login():
-    resp = requests.post("https://auth.service/token")
-    return {"token": resp.json()}
-""",
+                @RestController
+                @RequestMapping("/v1")
+                public class UserController {
+                    @GetMapping("/users/{id}")
+                    public String get(@PathVariable String id) {
+                        return "ok";
+                    }
+                }
+            """,
+        }
     )
 
-    manifest = RepoScanner().scan(str(repo))
+    manifest = repo_builder.scan()
     signals = list(StructureAnalyzer().analyze(manifest))
+    api_signals = [sig for sig in signals if sig.name == "architecture.api"]
 
-    api_signal = next(sig for sig in signals if sig.name == "architecture.api")
-    assert api_signal.metadata["framework"] == "FastAPI"
-    sequence = api_signal.metadata["sequence"]
-    assert sequence[0]["message"] == "GET /login"
-    assert any(step["to"] == "External service" for step in sequence)
+    values = sorted(sig.value for sig in api_signals)
+    assert "GET /users/{id}" in values
+    assert "GET /v1/users/{id}" in values
+
+    fastapi_signal = next(sig for sig in api_signals if sig.metadata.get("framework") == "FastAPI")
+    spring_signal = next(sig for sig in api_signals if sig.metadata.get("framework") == "Spring")
+    assert fastapi_signal.metadata["confidence"] >= 0.9
+    assert spring_signal.metadata["confidence"] >= 0.9
 
 
-def test_structure_analyzer_summarises_modules(tmp_path: Path) -> None:
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _write(repo / "services" / "svc.py", "print('hi')\n")
-    _write(repo / "services" / "__init__.py", "")
-    _write(repo / "docs" / "readme.md", "# Docs\n")
+def test_structure_analyzer_prefers_openapi_spec(repo_builder: RepoBuilder) -> None:
+    repo_builder.write(
+        {
+            "app/routes.py": """
+                from fastapi import FastAPI
 
-    manifest = RepoScanner().scan(str(repo))
+                app = FastAPI()
+
+                @app.get("/users/{id}")
+                def get_user(user_id: int):
+                    return {"id": user_id}
+            """,
+            "docs/openapi.json": json.dumps(
+                {
+                    "openapi": "3.0.0",
+                    "paths": {
+                        "/users/{id}": {
+                            "get": {
+                                "summary": "Fetch a user",
+                            }
+                        }
+                    },
+                }
+            ),
+        }
+    )
+
+    manifest = repo_builder.scan()
+    signals = list(StructureAnalyzer().analyze(manifest))
+    api_signals = [sig for sig in signals if sig.name == "architecture.api"]
+
+    assert api_signals
+    spec_signal = next(sig for sig in api_signals if sig.metadata.get("framework") == "spec")
+    assert spec_signal.metadata["file"] == "docs/openapi.json"
+    assert spec_signal.metadata["confidence"] == 1.0
+
+
+def test_structure_analyzer_summarises_modules(repo_builder: RepoBuilder) -> None:
+    repo_builder.write(
+        {
+            "services/svc.py": "print('hi')\n",
+            "services/__init__.py": "",
+            "docs/readme.md": "# Docs\n",
+        }
+    )
+
+    manifest = repo_builder.scan()
     signals = list(StructureAnalyzer().analyze(manifest))
 
     modules = next(sig for sig in signals if sig.name == "architecture.modules")
     module_names = [module["name"] for module in modules.metadata["modules"]]
     assert "services" in module_names
+
+
+def test_spring_method_level_request_mapping(repo_builder: RepoBuilder) -> None:
+    repo_builder.write(
+        {
+            "src/PingController.java": """
+                import org.springframework.web.bind.annotation.RequestMapping;
+                import org.springframework.web.bind.annotation.RestController;
+                import org.springframework.web.bind.annotation.RequestMethod;
+
+                @RestController
+                public class PingController {
+                    @RequestMapping(value = "/ping", method = RequestMethod.GET)
+                    public String ping() {
+                        return "pong";
+                    }
+                }
+            """,
+        }
+    )
+
+    manifest = repo_builder.scan()
+    signals = list(StructureAnalyzer().analyze(manifest))
+    api_paths = {sig.metadata["path"] for sig in signals if sig.name == "architecture.api"}
+    assert "/ping" in api_paths

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests._fixtures.repo_builder import RepoBuilder
+
+
+@pytest.fixture
+def repo_builder(tmp_path: Path) -> RepoBuilder:
+    """Provide a reusable repo builder rooted at the pytest tmp_path."""
+    return RepoBuilder(tmp_path)


### PR DESCRIPTION
As‑is, the StructureAnalyzer will work on the module summary for any repo, including Java/Spring Boot (because that part just groups files by top‑level folder). But the API and entity detectors are Python/JS‑specific, so it will not find Spring MVC endpoints or JPA entities out of the box.

We can abstract by decoupling endpoint extraction into pluggable detectors: (1) parse specs if present, (2) use small framework‑specific AST queries (Tree‑sitter), and (3) fall back to a cautious generic regex. Normalize and score results, then emit existing Signals. This makes the analyzer language‑agnostic while staying simple to extend.

Refactoring StructureAnalyzer around a three-layer EndpointDetector pipeline—spec sniffing, framework-specific extractors, then a cautious heuristic pass—will let us keep emitting the same Signals while covering Spring MVC, JAX‑RS, Rails, ASP.NET, etc. 

1. Introduce the shared Endpoint dataclass plus a DetectorRegistry (with confidence scoring and path normalization). 
2. Plug it into StructureAnalyzer.analyze, replacing the current Python/JS-only logic. 
3. Seed the registry with concrete detectors: start with SpecDetector, FastAPI/Express (porting the existing regex), and a Spring MVC plugin to validate the abstraction before adding more frameworks. 
4. Update/add tests in tests/analyzers/test_structure.py so we cover the new registry and Spring sample fixtures.